### PR TITLE
Implement Array for all arrays generically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-vec-deque"
-version = "0.1.12"
+version = "0.2.0"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 rust-version = "1.56"
 description = "A fixed-size, zero-allocation circular buffer for Rust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/udoprog/fixed-vec-deque"
 license = "MIT/Apache-2.0"
 keywords = ["data-structures"]
 categories = ["data-structures"]
+edition = "2021"
 
 [features]
 unstable = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,8 @@
 //! [`pop_back`]: https://docs.rs/fixed-vec-deque/latest/fixed_vec_deque/struct.FixedVecDeque.html#method.pop_back
 //! [`pop_front`]: https://docs.rs/fixed-vec-deque/latest/fixed_vec_deque/struct.FixedVecDeque.html#method.pop_front
 
+#![cfg_attr(nightly, feature(test))]
+
 /// Code extensively based on Rust stdlib:
 /// https://github.com/rust-lang/rust/blob/e8aef7cae14bc7a56859408c90253e9bcc07fcff/src/liballoc/collections/vec_deque.rs
 /// And rust-smallvec:
@@ -127,8 +129,6 @@ use std::hash;
 use std::iter::{repeat, FromIterator};
 use std::marker;
 use std::mem;
-
-
 use std::ops::{Index, IndexMut};
 use std::ptr;
 use std::slice;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,8 +117,6 @@
 //! [`pop_back`]: https://docs.rs/fixed-vec-deque/latest/fixed_vec_deque/struct.FixedVecDeque.html#method.pop_back
 //! [`pop_front`]: https://docs.rs/fixed-vec-deque/latest/fixed_vec_deque/struct.FixedVecDeque.html#method.pop_front
 
-#![cfg_attr(nightly, feature(test))]
-
 /// Code extensively based on Rust stdlib:
 /// https://github.com/rust-lang/rust/blob/e8aef7cae14bc7a56859408c90253e9bcc07fcff/src/liballoc/collections/vec_deque.rs
 /// And rust-smallvec:
@@ -129,6 +127,8 @@ use std::hash;
 use std::iter::{repeat, FromIterator};
 use std::marker;
 use std::mem;
+
+
 use std::ops::{Index, IndexMut};
 use std::ptr;
 use std::slice;
@@ -1454,18 +1454,43 @@ pub unsafe trait Array {
     }
 }
 
-macro_rules! impl_array(
-    ($($size:expr),+) => {
-        $(
-            unsafe impl<T> Array for [T; $size] where T: Default {
-                type Item = T;
-                fn size() -> usize { $size }
-                fn ptr(&self) -> *const T { self.as_ptr() }
-                fn ptr_mut(&mut self) -> *mut T { self.as_mut_ptr() }
-            }
-        )+
+unsafe impl<const N: usize, T> Array for [T; N] {
+    type Item = T;
+
+    #[inline]
+    fn size() -> usize {
+        N
     }
-);
+
+    #[inline]
+    fn ptr(&self) -> *const Self::Item {
+        self.as_ptr()
+    }
+
+    #[inline]
+    fn ptr_mut(&mut self) -> *mut Self::Item {
+        self.as_mut_ptr()
+    }
+}
+
+unsafe impl<const N: usize, T> Array for &mut [T; N] {
+    type Item = T;
+
+    #[inline]
+    fn size() -> usize {
+        N
+    }
+
+    #[inline]
+    fn ptr(&self) -> *const Self::Item {
+        self.as_ptr()
+    }
+
+    #[inline]
+    fn ptr_mut(&mut self) -> *mut Self::Item {
+        self.as_mut_ptr()
+    }
+}
 
 impl<A> Eq for FixedVecDeque<A>
 where
@@ -1522,46 +1547,35 @@ where
 }
 
 macro_rules! impl_slice_eq {
-    ($Lhs: ty, $Rhs: ty) => {
-        impl_slice_eq! { $Lhs, $Rhs, Sized }
-    };
-    ($Lhs: ty, $Rhs: ty, $Bound: ident) => {
-        impl<'a, 'b, A, B> PartialEq<$Rhs> for $Lhs
-        where
-            A: Array,
-            A::Item: $Bound + PartialEq<B>,
-        {
-            fn eq(&self, other: &$Rhs) -> bool {
-                if self.len() != other.len() {
-                    return false;
-                }
-                let (sa, sb) = self.as_slices();
-                let (oa, ob) = other[..].split_at(sa.len());
-                sa == oa && sb == ob
-            }
+    ($self:ident, $other:ident) => {
+        if $self.len() != $other.len() {
+            return false;
+        } else {
+            let (sa, sb) = $self.as_slices();
+            let (oa, ob) = $other[..].split_at(sa.len());
+            sa == oa && sb == ob
         }
     };
 }
 
-impl_slice_eq! { FixedVecDeque<A>, Vec<B> }
-impl_slice_eq! { FixedVecDeque<A>, &'b [B] }
-impl_slice_eq! { FixedVecDeque<A>, &'b mut [B] }
-
-macro_rules! array_impls {
-    ($($N: expr)+) => {
-        $(
-            impl_slice_eq! { FixedVecDeque<A>, [B; $N] }
-            impl_slice_eq! { FixedVecDeque<A>, &'b [B; $N] }
-            impl_slice_eq! { FixedVecDeque<A>, &'b mut [B; $N] }
-        )+
+impl<A, B> PartialEq<[B]> for FixedVecDeque<A>
+where
+    A: Array,
+    A::Item: PartialEq<B>,
+{
+    fn eq(&self, other: &[B]) -> bool {
+        impl_slice_eq!(self, other)
     }
 }
 
-array_impls! {
-     0  1  2  3  4  5  6  7  8  9
-    10 11 12 13 14 15 16 17 18 19
-    20 21 22 23 24 25 26 27 28 29
-    30 31 32
+impl<const N: usize, A, B> PartialEq<[B; N]> for FixedVecDeque<A>
+where
+    A: Array,
+    A::Item: PartialEq<B>,
+{
+    fn eq(&self, other: &[B; N]) -> bool {
+        impl_slice_eq!(self, other)
+    }
 }
 
 impl<A> PartialOrd for FixedVecDeque<A>
@@ -1584,12 +1598,6 @@ where
         self.iter().cmp(other.iter())
     }
 }
-
-impl_array!(
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 36, 0x40, 0x80, 0x100,
-    0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000, 0x10000, 0x20000, 0x40000, 0x80000,
-    0x100000
-);
 
 /// Returns the two slices that cover the `FixedVecDeque`'s valid range
 trait RingSlices: Sized {


### PR DESCRIPTION
Hi,
I really like your crate and implement the Array trait for all arrays (with [ConstParams](https://doc.rust-lang.org/reference/items/generics.html)). This makes using the crate much more flexible. You could consider rewriting the whole crate using no trait at all, just this, but that's up to you to decide.

I also changed the implementation of PartialEq for slices a bit. They are now implemented for [B]. I removed the implementation for Vec<B> since it's not really necessary (since every Vec<B> can be treated as a &[B]).

Removing this however is a *breaking* API change. Therefore I bumped the version number.

I also fixed the rust edition, that's not really necessary (The MSRV is 2021 anyway), however it improves clarity.

Have a nice day :)

PS.: I somehow couldn't get the benchmarks to run, but I'm pretty certain I didn't introduce worse performance.